### PR TITLE
Tell git to use the correct path for CA certificate

### DIFF
--- a/conda/linux_dev/AppDir/AppRun
+++ b/conda/linux_dev/AppDir/AppRun
@@ -8,4 +8,5 @@ export QT_QPA_PLATFORM_PLUGIN_PATH=$HERE/usr/plugins
 export QT_XKB_CONFIG_ROOT=$HERE/usr/lib
 export FONTCONFIG_FILE=/etc/fonts/fonts.conf
 export FONTCONFIG_PATH=/etc/fonts
+export GIT_SSL_CAINFO=$HERE/usr/ssl/cacert.pem
 ${HERE}/usr/bin/FreeCAD "$@"

--- a/conda/linux_stable/AppDir/AppRun
+++ b/conda/linux_stable/AppDir/AppRun
@@ -8,4 +8,5 @@ export QT_QPA_PLATFORM_PLUGIN_PATH=$HERE/usr/plugins
 export QT_XKB_CONFIG_ROOT=$HERE/usr/lib
 export FONTCONFIG_FILE=/etc/fonts/fonts.conf
 export FONTCONFIG_PATH=/etc/fonts
+export GIT_SSL_CAINFO=$HERE/usr/ssl/cacert.pem
 ${HERE}/usr/bin/FreeCAD "$@"


### PR DESCRIPTION
The issue of git using the wrong certificate verify location (/home/travis/build/FreeCAD/FreeCAD-AppImage/conda/linux_stable/AppDir/usr/ssl/cacert.pem) has been reported here:
https://forum.freecadweb.org/viewtopic.php?t=36255
https://forum.freecadweb.org/viewtopic.php?f=12&t=36210
https://forum.freecadweb.org/viewtopic.php?f=10&t=34981&start=20#p300154
https://forum.freecadweb.org/viewtopic.php?t=35477

As far as I can tell, this absolute path from the travis build is baked into the curl library. However it seems git can be told to pass an alternative location to curl using the GIT_SSL_CAINFO environment variable, so this is the solution proposed here. This change to the AppRun script fixed the problem on for me.
