### PR TITLE
print installed dependencies during startup

### DIFF
--- a/conda/linux_dev/AppDir/AppRun
+++ b/conda/linux_dev/AppDir/AppRun
@@ -1,14 +1,14 @@
 #!/bin/bash
 HERE="$(dirname "$(readlink -f "${0}")")"
-echo ${HERE}
-export PREFIX=$HERE/usr
-export LD_LIBRARY_PATH=$HERE/usr/lib
-export PYTHONHOME=$HERE/usr
-# export QT_QPA_PLATFORM_PLUGIN_PATH=$HERE/usr/plugins
-# export QT_XKB_CONFIG_ROOT=$HERE/usr/lib
+cat ${HERE}/packages.txt
+export PREFIX=${HERE}/usr
+export LD_LIBRARY_PATH=${HERE}/usr/lib
+export PYTHONHOME=${HERE}/usr
+# export QT_QPA_PLATFORM_PLUGIN_PATH=${HERE}/usr/plugins
+# export QT_XKB_CONFIG_ROOT=${HERE}/usr/lib
 export FONTCONFIG_FILE=/etc/fonts/fonts.conf
 export FONTCONFIG_PATH=/etc/fonts
-# export QTWEBENGINEPROCESS_PATH=$HERE/usr/libexec/QtWebEngineProcess
+# export QTWEBENGINEPROCESS_PATH=${HERE}/usr/libexec/QtWebEngineProcess
 
 # SSL
 # https://forum.freecadweb.org/viewtopic.php?f=4&t=34873&start=20#p327416

--- a/conda/linux_dev/linux_dev.sh
+++ b/conda/linux_dev/linux_dev.sh
@@ -14,14 +14,14 @@ conda uninstall -p AppDir/usr gtk2 gdk-pixbuf llvm-tools \
                               llvmdev clangdev clang clang-tools \
                               clangxx libclang libllvm9 --force -y
 
-conda list -p AppDir/usr
-
 version_name=$(conda run -p AppDir/usr python get_freecad_version.py)
 
 # installing some additional libraries with pip
 conda run -p AppDir/usr pip install pycollada
 conda run -p AppDir/usr pip install https://github.com/looooo/freecad.python/archive/master.zip
 
+conda list -p AppDir/usr > AppDir/packages.txt
+sed -i "1s/.*/\n\nLIST OF PACKAGES:/"  AppDir/packages.txt
 
 # delete unnecessary stuff
 rm -rf AppDir/usr/include

--- a/conda/linux_dev/linux_dev.sh
+++ b/conda/linux_dev/linux_dev.sh
@@ -43,7 +43,6 @@ cp qt.conf AppDir/usr/bin/
 cp qt.conf AppDir/usr/libexec/
 
 # Remove __pycache__ folders and .pyc files
-conda deactivate
 find . -path "*/__pycache__/*" -delete
 find . -name "*.pyc" -type f -delete
 

--- a/conda/linux_dev/linux_dev.sh
+++ b/conda/linux_dev/linux_dev.sh
@@ -18,7 +18,6 @@ version_name=$(conda run -p AppDir/usr python get_freecad_version.py)
 
 # installing some additional libraries with pip
 conda run -p AppDir/usr pip install pycollada
-conda run -p AppDir/usr pip install https://github.com/looooo/freecad.python/archive/master.zip
 
 conda list -p AppDir/usr > AppDir/packages.txt
 sed -i "1s/.*/\n\nLIST OF PACKAGES:/"  AppDir/packages.txt

--- a/conda/osx_dev/APP/FreeCAD.app/Contents/MacOS/FreeCAD
+++ b/conda/osx_dev/APP/FreeCAD.app/Contents/MacOS/FreeCAD
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 HERE=$(dirname "$(dirname "$0")")
 cat ${HERE}/packages.txt
-export PREFIX=$HERE/Resources
-export LD_LIBRARY_PATH=$PREFIX/lib
-export PYTHONHOME=$PREFIX
-# export QT_QPA_PLATFORM_PLUGIN_PATH=$PREFIX/plugins
-# export QT_XKB_CONFIG_ROOT=$PREFIX/lib
+export PREFIX=${HERE}/Resources
+export LD_LIBRARY_PATH=${PREFIX}/lib
+export PYTHONHOME=${PREFIX}
+# export QT_QPA_PLATFORM_PLUGIN_PATH=${PREFIX}/plugins
+# export QT_XKB_CONFIG_ROOT=${PREFIX}/lib
 export FONTCONFIG_FILE=/etc/fonts/fonts.conf
 export FONTCONFIG_PATH=/etc/fonts
 export LANG="UTF-8"  # https://forum.freecadweb.org/viewtopic.php?f=22&t=42644
-"$PREFIX/bin/freecad" $@
+"${PREFIX}/bin/freecad" $@

--- a/conda/osx_dev/APP/FreeCAD.app/Contents/MacOS/FreeCAD
+++ b/conda/osx_dev/APP/FreeCAD.app/Contents/MacOS/FreeCAD
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 HERE=$(dirname "$(dirname "$0")")
+cat ${HERE}/packages.txt
 export PREFIX=$HERE/Resources
 export LD_LIBRARY_PATH=$PREFIX/lib
 export PYTHONHOME=$PREFIX

--- a/conda/osx_dev/osx_dev.sh
+++ b/conda/osx_dev/osx_dev.sh
@@ -17,7 +17,6 @@ version_name=$(conda run -p APP/FreeCAD.app/Contents/Resources python get_freeca
 
 # installing some additional libraries with pip
 conda run -p APP/FreeCAD.app/Contents/Resources pip install pycollada
-conda run -p AppDir/usr pip install https://github.com/looooo/freecad.python/archive/master.zip
 
 conda list -p APP/FreeCAD.app/Contents/Resources > APP/FreeCAD.app/packages.txt
 sed -i "1s/.*/\n\nLIST OF PACKAGES:/"  APP/FreeCAD.app/packages.txt

--- a/conda/osx_dev/osx_dev.sh
+++ b/conda/osx_dev/osx_dev.sh
@@ -12,13 +12,15 @@ conda create \
 
 # uninstall some packages not needed
 conda uninstall -p APP/FreeCAD.app/Contents/Resources gtk2 gdk-pixbuf  llvmdev clangdev --force -y
-conda list -p APP/FreeCAD.app/Contents/Resources
 
 version_name=$(conda run -p APP/FreeCAD.app/Contents/Resources python get_freecad_version.py)
 
 # installing some additional libraries with pip
 conda run -p APP/FreeCAD.app/Contents/Resources pip install pycollada
 conda run -p AppDir/usr pip install https://github.com/looooo/freecad.python/archive/master.zip
+
+conda list -p APP/FreeCAD.app/Contents/Resources > APP/FreeCAD.app/packages.txt
+sed -i "1s/.*/\n\nLIST OF PACKAGES:/"  APP/FreeCAD.app/packages.txt
 
 
 # delete unnecessary stuff

--- a/conda/osx_dev/osx_dev.sh
+++ b/conda/osx_dev/osx_dev.sh
@@ -42,7 +42,6 @@ cp qt.conf APP/FreeCAD.app/Contents/Resources/bin/
 cp qt.conf APP/FreeCAD.app/Contents/Resources/libexec/
 
 # Remove __pycache__ folders and .pyc files
-conda deactivate
 find . -path "*/__pycache__/*" -delete
 find . -name "*.pyc" -type f -delete
 


### PR DESCRIPTION
This will help to debug issues with dependencies. It simple writes all dependencies installed in the environment created on travis into a file and prints this file when the user starts the application.

It's also possible to print this information only if the user adds an option like (--deps). But I am not sure how we can distinguish between options passed to freecad and options which should be handled by the appimage/dmg.

@triplus  